### PR TITLE
Drop library path change

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,13 +15,5 @@ fi
             --with-icu \
             --without-python
 make
-
-# Correct weirdly linked library paths.
-if [[ $(uname) == 'Darwin' ]]; then
-  LIBDIR="${PREFIX}/lib"
-  LIBICUDATA="`cd ${LIBDIR} && ls libicudata.*.*.dylib`"
-  find "${SRC_DIR}/.libs" -type f | xargs -I {} install_name_tool -change "../lib/${LIBICUDATA}" "${PREFIX}/lib/${LIBICUDATA}" {} || true
-#   find "${SRC_DIR}/python/.libs" -type f | xargs -I {} install_name_tool -change "../lib/${LIBICUDATA}" "${PREFIX}/lib/${LIBICUDATA}" {} || true
-fi
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make check
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 59d281614c87d0c767134c55de20a8a9
 
 build:
-    number: 0
+    number: 1
     skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
This removes some code that patched the library paths for things dependent on `libicudata.*.*.dylib`. However, as the core issue ( https://github.com/conda-forge/icu-feedstock/pull/3 ) is being resolved, this patching will no longer be necessary going forward. Once `icu` is released, we can re-test and see if this fixes the problem.