### PR TITLE
build without-lzma

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [[ $(uname) == 'Darwin' ]]; then
+if [[ $(uname) == Darwin ]]; then
   export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
-elif [[ $(uname) == 'Linux' ]]; then
+elif [[ $(uname) == Linux ]]; then
   export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
 fi
 
@@ -10,9 +10,9 @@ fi
 
 ./configure --prefix="${PREFIX}" \
             --with-iconv="${PREFIX}" \
-            --with-lzma="${PREFIX}" \
             --with-zlib="${PREFIX}" \
             --with-icu \
+            --without-lzma \
             --without-python
 make
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 59d281614c87d0c767134c55de20a8a9
 
 build:
-    number: 1
+    number: 2
     skip: True  # [win]
 
 requirements:
@@ -21,12 +21,10 @@ requirements:
         - pkg-config
         - icu
         - libiconv
-        - xz
         - zlib
     run:
         - icu
         - libiconv
-        - xz
         - zlib
 
 test:


### PR DESCRIPTION
There is a `lzma` version mismatch that does not show in the tests here but does interferes with `gdal`.