### PR TITLE
Pin xz 5.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
       conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://xmlsoft.org/
 
 Package license: MIT
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: The XML C parser and toolkit of Gnome
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 59d281614c87d0c767134c55de20a8a9
 
 build:
-    number: 4
+    number: 5
     skip: True  # [win]
 
 requirements:
@@ -22,12 +22,12 @@ requirements:
         - icu
         - libiconv
         - zlib
-        - xz
+        - xz 5.0.*  # [not win]
     run:
         - icu
         - libiconv
         - zlib
-        - xz
+        - xz 5.0.*  # [not win]
 
 test:
     files:


### PR DESCRIPTION
Pinning `libzma` to 5.0.5 to avoid issues with Python 3.4 and 3.5