### PR TITLE
add Windows build

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,6 @@
+cd win32
+cscript configure.js compiler=msvc prefix=%LIBRARY_PREFIX% ^
+        include=%LIBRARY_INC% lib=%LIBRARY_LIB% ^
+        icu=no zlib=yes iconv=no
+nmake /f Makefile.msvc
+nmake /f Makefile.msvc install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,31 +5,37 @@ package:
     version: {{ version }}
 
 source:
-    fn: libxml2-{{ version }}.tar.xz
-    url: https://git.gnome.org/browse/libxml2/snapshot/libxml2-{{ version }}.tar.xz
-    md5: 59d281614c87d0c767134c55de20a8a9
+    fn: libxml2-{{ version }}.tar.gz
+    url: ftp://xmlsoft.org/libxml2/libxml2-{{ version }}.tar.gz
+    sha256: 4de9e31f46b44d34871c22f54bfc54398ef124d6f7cafb1f4a5958fbcd3ba12d
 
 build:
     number: 5
-    skip: True  # [win]
+    features:
+        - vc9     # [win and py27]
+        - vc10    # [win and py34]
+        - vc14    # [win and py35]
 
 requirements:
     build:
-        - autoconf
-        - automake
-        - libtool
-        - pkg-config
-        - icu
-        - libiconv
+        - python  # [win]
+        - autoconf  # [not win]
+        - automake  # [not win]
+        - libtool  # [not win]
+        - pkg-config  # [not win]
+        - icu  # [not win]
+        - libiconv  # [not win]
         - zlib
         - xz 5.0.*  # [not win]
     run:
-        - icu
-        - libiconv
+        - icu  # [not win]
+        - libiconv  # [not win]
         - zlib
         - xz 5.0.*  # [not win]
 
 test:
+    requires:
+        - python {{ environ['PY_VER'] + '*' }}  # [win]
     files:
         - test.xml
     commands:
@@ -44,3 +50,4 @@ extra:
     recipe-maintainers:
         - ocefpaf
         - jakirkham
+        - msarahan


### PR DESCRIPTION
Notes on what it will take to make Windows have more libraries tied in here:

- xz now builds with VS 2013+ (C99 support).  Can potentially add it for VS 2015.
- ICU is available for windows, but libxml2 wants icu.lib, and I'm not sure where that comes from.  All ICU libraries are icu???.lib - they all are some part of ICU, not a single library
- Iconv - ??? - I have built this for SVN before, but it was part of a bundle of stuff there.  It was very hard to build.  I'm not sure what it would add here.