### PR TITLE
Pin icu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |
@@ -23,7 +26,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Terminology
 
 Current build status
 ====================
+
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/libxml2-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/libxml2-feedstock)
 OSX: [![TravisCI](https://travis-ci.org/conda-forge/libxml2-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/libxml2-feedstock) 
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/libxml2-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/libxml2-feedstock/branch/master)

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -29,7 +29,7 @@ cat << EOF | docker run -i \
                         -v ${RECIPE_ROOT}:/recipe_root \
                         -v ${FEEDSTOCK_ROOT}:/feedstock_root \
                         -a stdin -a stdout -a stderr \
-                        pelson/obvious-ci:latest_x64 \
+                        condaforge/linux-anvil \
                         bash || exit $?
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
@@ -40,7 +40,7 @@ echo "$config" > ~/.condarc
 conda clean --lock
 
 conda update --yes --all
-conda install --yes conda-build==1.18.2
+conda install --yes conda-build
 conda info
 
 # Embarking on 1 case(s).

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,7 @@ dependencies:
   # Note, we used to use the naive caching of docker images, but found that it was quicker
   # just to pull each time. #rollondockercaching
   override:
-    - docker pull pelson/obvious-ci:latest_x64
-#    - docker pull pelson/conda32_obvious_ci
+    - docker pull condaforge/linux-anvil
 
 test:
   override:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 59d281614c87d0c767134c55de20a8a9
 
 build:
-    number: 5
+    number: 6
     skip: True  # [win]
 
 requirements:
@@ -19,14 +19,14 @@ requirements:
         - automake
         - libtool
         - pkg-config
-        - icu
+        - icu 56.*
         - libiconv
-        - zlib
+        - zlib 1.2*
         - xz 5.0.*  # [not win]
     run:
         - icu
         - libiconv
-        - zlib
+        - zlib 1.2*
         - xz 5.0.*  # [not win]
 
 test:
@@ -34,6 +34,7 @@ test:
         - test.xml
     commands:
         - xmllint test.xml
+        - conda inspect linkages -n _test libxml2  # [linux]
 
 about:
     home: http://xmlsoft.org/


### PR DESCRIPTION
@pelson, @jakirkham, and @msarahan I found some issues mixing with `icu 54` (defaults) vs `icu 56` (conda-forge), so I am pinning our packages to `icu 56`. (Already updated the wiki and preparing PR to all packages that use icu.)