### PR TITLE
Make and install a pkg-config file on Windows.

### DIFF
--- a/recipe/0002-Make-and-install-a-pkg-config-file-on-Windows.patch
+++ b/recipe/0002-Make-and-install-a-pkg-config-file-on-Windows.patch
@@ -1,0 +1,49 @@
+From ecc4cbe262900a82c4be4d7146ff58ac034ef20e Mon Sep 17 00:00:00 2001
+From: Peter Williams <peter@newton.cx>
+Date: Wed, 5 Sep 2018 16:50:54 -0400
+Subject: [PATCH] Make and install a pkg-config file on Windows.
+
+---
+ win32/Makefile.msvc | 19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/win32/Makefile.msvc b/win32/Makefile.msvc
+index 491dc88..567e001 100644
+--- a/win32/Makefile.msvc
++++ b/win32/Makefile.msvc
+@@ -282,7 +282,22 @@ _VC_MANIFEST_EMBED_EXE=
+ _VC_MANIFEST_EMBED_DLL=
+ !endif
+ 
+-all : libxml libxmla libxmladll utils
++all : libxml libxmla libxmladll utils libxml-2.0.pc
++
++# Note hardcoded libraries and trouble getting dollar-sign/brace variables working
++libxml-2.0.pc:
++        echo prefix=$(PREFIX:\=/) >$@
++        echo exec_prefix=$(PREFIX:\=/) >>$@
++        echo libdir=$(LIBPREFIX:\=/) >>$@
++        echo includedir=$(INCPREFIX:\=/) >>$@
++        echo modules=0 >>$@
++        echo Name: libXML >>$@
++        echo Version: $(LIBXML_MAJOR_VERSION).$(LIBXML_MINOR_VERSION).$(LIBXML_MICRO_VERSION) >>$@
++        echo Description: libXML library version2. >>$@
++        echo Requires: >>$@
++        echo Libs: -L$(LIBPREFIX:\=/) -lxml2 >>$@
++        echo Libs.private: -liconv -lz >>$@
++        echo Cflags: -I$(INCPREFIX:\=/)/libxml >>$@
+ 
+ libxml : $(BINDIR)\$(XML_SO) 
+ 
+@@ -320,6 +335,8 @@ install-libs : all
+ install : install-libs 
+ 	copy $(BINDIR)\*.exe $(BINPREFIX)
+ 	-copy $(BINDIR)\*.pdb $(BINPREFIX)
++	if not exist $(LIBPREFIX)\pkgconfig mkdir $(LIBPREFIX)\pkgconfig
++	copy libxml-2.0.pc $(LIBPREFIX)\pkgconfig
+ 
+ install-dist : install-libs 
+ 	copy $(BINDIR)\xml*.exe $(BINPREFIX)
+-- 
+2.17.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,11 @@ source:
   patches:
     # Some C99 that vs2008 can't cope with
     - 0001-C89-for-VS2008.patch
+    - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch
     - 0004-CVE-2017-8872.patch
 
 build:
-  number: 3
+  number: 4
   run_exports:
     # remove symbols at minor versions.
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/
@@ -27,6 +28,7 @@ requirements:
     - libtool  # [not win]
     - pkg-config  # [not win]
     - make  # [not win]
+    - m2-patch  # [win]
   host:
     - icu  # [not win]
     - libiconv


### PR DESCRIPTION
The Unix versions of the package provide a pkg-config file, but the CMake-based build doesn't. Here we add CMake code to create the file in a way analogous to what the autotools do.

* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.