### PR TITLE
Tweak the pkg-config file on Windows

### DIFF
--- a/recipe/0002-Make-and-install-a-pkg-config-file-on-Windows.patch
+++ b/recipe/0002-Make-and-install-a-pkg-config-file-on-Windows.patch
@@ -1,17 +1,17 @@
-From ecc4cbe262900a82c4be4d7146ff58ac034ef20e Mon Sep 17 00:00:00 2001
+From f90d931fa6f400065189b44d00273979709c700b Mon Sep 17 00:00:00 2001
 From: Peter Williams <peter@newton.cx>
 Date: Wed, 5 Sep 2018 16:50:54 -0400
 Subject: [PATCH] Make and install a pkg-config file on Windows.
 
 ---
- win32/Makefile.msvc | 19 ++++++++++++++++++-
- 1 file changed, 18 insertions(+), 1 deletion(-)
+ win32/Makefile.msvc | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
 
 diff --git a/win32/Makefile.msvc b/win32/Makefile.msvc
-index 491dc88..567e001 100644
+index 491dc88..415ec0b 100644
 --- a/win32/Makefile.msvc
 +++ b/win32/Makefile.msvc
-@@ -282,7 +282,22 @@ _VC_MANIFEST_EMBED_EXE=
+@@ -282,7 +282,21 @@ _VC_MANIFEST_EMBED_EXE=
  _VC_MANIFEST_EMBED_DLL=
  !endif
  
@@ -29,13 +29,12 @@ index 491dc88..567e001 100644
 +        echo Version: $(LIBXML_MAJOR_VERSION).$(LIBXML_MINOR_VERSION).$(LIBXML_MICRO_VERSION) >>$@
 +        echo Description: libXML library version2. >>$@
 +        echo Requires: >>$@
-+        echo Libs: -L$(LIBPREFIX:\=/) -lxml2 >>$@
-+        echo Libs.private: -liconv -lz >>$@
++        echo Libs: -L$(LIBPREFIX:\=/) -lxml2 -liconv -lz >>$@
 +        echo Cflags: -I$(INCPREFIX:\=/)/libxml >>$@
  
  libxml : $(BINDIR)\$(XML_SO) 
  
-@@ -320,6 +335,8 @@ install-libs : all
+@@ -320,6 +334,8 @@ install-libs : all
  install : install-libs 
  	copy $(BINDIR)\*.exe $(BINPREFIX)
  	-copy $(BINDIR)\*.pdb $(BINPREFIX)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0004-CVE-2017-8872.patch
 
 build:
-  number: 4
+  number: 5
   run_exports:
     # remove symbols at minor versions.
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/


### PR DESCRIPTION
Libs.private doesn't work well since inter-DLL dependencies are problematic.