### PR TITLE
Re-add the patch to generate a pkg-config file on Windows

### DIFF
--- a/recipe/0002-Make-and-install-a-pkg-config-file-on-Windows.patch
+++ b/recipe/0002-Make-and-install-a-pkg-config-file-on-Windows.patch
@@ -1,0 +1,48 @@
+From f90d931fa6f400065189b44d00273979709c700b Mon Sep 17 00:00:00 2001
+From: Peter Williams <peter@newton.cx>
+Date: Wed, 5 Sep 2018 16:50:54 -0400
+Subject: [PATCH] Make and install a pkg-config file on Windows.
+
+---
+ win32/Makefile.msvc | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/win32/Makefile.msvc b/win32/Makefile.msvc
+index 491dc88..415ec0b 100644
+--- a/win32/Makefile.msvc
++++ b/win32/Makefile.msvc
+@@ -282,7 +282,21 @@ _VC_MANIFEST_EMBED_EXE=
+ _VC_MANIFEST_EMBED_DLL=
+ !endif
+ 
+-all : libxml libxmla libxmladll utils
++all : libxml libxmla libxmladll utils libxml-2.0.pc
++
++# Note hardcoded libraries and trouble getting dollar-sign/brace variables working
++libxml-2.0.pc:
++        echo prefix=$(PREFIX:\=/) >$@
++        echo exec_prefix=$(PREFIX:\=/) >>$@
++        echo libdir=$(LIBPREFIX:\=/) >>$@
++        echo includedir=$(INCPREFIX:\=/) >>$@
++        echo modules=0 >>$@
++        echo Name: libXML >>$@
++        echo Version: $(LIBXML_MAJOR_VERSION).$(LIBXML_MINOR_VERSION).$(LIBXML_MICRO_VERSION) >>$@
++        echo Description: libXML library version2. >>$@
++        echo Requires: >>$@
++        echo Libs: -L$(LIBPREFIX:\=/) -lxml2 -liconv -lz >>$@
++        echo Cflags: -I$(INCPREFIX:\=/)/libxml >>$@
+ 
+ libxml : $(BINDIR)\$(XML_SO) 
+ 
+@@ -320,6 +334,8 @@ install-libs : all
+ install : install-libs 
+ 	copy $(BINDIR)\*.exe $(BINPREFIX)
+ 	-copy $(BINDIR)\*.pdb $(BINPREFIX)
++	if not exist $(LIBPREFIX)\pkgconfig mkdir $(LIBPREFIX)\pkgconfig
++	copy libxml-2.0.pc $(LIBPREFIX)\pkgconfig
+ 
+ install-dist : install-libs 
+ 	copy $(BINDIR)\xml*.exe $(BINPREFIX)
+-- 
+2.17.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,10 +8,11 @@ source:
   url: http://xmlsoft.org/sources/libxml2-{{ version }}.tar.gz
   sha256: 94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871
   patches:
+    - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch
     - 0004-CVE-2017-8872.patch
 
 build:
-  number: 3
+  number: 4
   run_exports:
     # remove symbols at minor versions.
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/
@@ -25,6 +26,7 @@ requirements:
     - libtool  # [not win]
     - pkg-config  # [not win]
     - make  # [not win]
+    - m2-patch  # [win]
   host:
     - icu  # [not win]
     - libiconv  # [not linux]


### PR DESCRIPTION
CC @ocefpaf — you took this out in the update to 2.9.9. Was there a specific reason? To the best of my knowledge the pkg-config file is needed by `fontconfig`, `tectonic`, and possible others.

#### Checklist

* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.