### PR TITLE
Temporarily revert #48

### DIFF
--- a/.ci_support/linux_aarch64_target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_target_platformlinux-aarch64.yaml
@@ -18,9 +18,13 @@ docker_image:
 - condaforge/linux-anvil-aarch64
 icu:
 - '64.2'
+libiconv:
+- '1.15'
 pin_run_as_build:
   icu:
     max_pin: x
+  libiconv:
+    max_pin: x.x
   xz:
     max_pin: x.x
   zlib:

--- a/.ci_support/linux_ppc64le_target_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_target_platformlinux-ppc64le.yaml
@@ -12,9 +12,13 @@ docker_image:
 - condaforge/linux-anvil-ppc64le
 icu:
 - '64.2'
+libiconv:
+- '1.15'
 pin_run_as_build:
   icu:
     max_pin: x
+  libiconv:
+    max_pin: x.x
   xz:
     max_pin: x.x
   zlib:

--- a/.ci_support/linux_target_platformlinux-64.yaml
+++ b/.ci_support/linux_target_platformlinux-64.yaml
@@ -12,9 +12,13 @@ docker_image:
 - condaforge/linux-anvil-comp7
 icu:
 - '64.2'
+libiconv:
+- '1.15'
 pin_run_as_build:
   icu:
     max_pin: x
+  libiconv:
+    max_pin: x.x
   xz:
     max_pin: x.x
   zlib:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0004-CVE-2017-8872.patch
 
 build:
-  number: 4
+  number: 5
   run_exports:
     # remove symbols at minor versions.
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,12 @@ requirements:
     - m2-patch  # [win]
   host:
     - icu  # [not win]
-    - libiconv  # [not linux]
+    - libiconv
+    - xz  # [not win]
+    - zlib
+  run:
+    - icu  # [not win]
+    - libiconv
     - xz  # [not win]
     - zlib
 


### PR DESCRIPTION
As per discussion in #48 and #49, we want to make this change but it will break depending packages until we complete a full migration, and we don't expect that to happen for a little while. So in the name of safety, and to get the changes in #49 propagated, this reverts #48.

CC @ocefpaf @msarahan @isuruf.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.