### PR TITLE
Fix again incomplete .pc file on Windows

### DIFF
--- a/recipe/0002-Make-and-install-a-pkg-config-file-on-Windows.patch
+++ b/recipe/0002-Make-and-install-a-pkg-config-file-on-Windows.patch
@@ -30,7 +30,7 @@ index 491dc88..415ec0b 100644
 +        echo Description: libXML library version2. >>$@
 +        echo Requires: >>$@
 +        echo Libs: -L$(LIBPREFIX:\=/) -lxml2 -liconv -lz >>$@
-+        echo Cflags: -I$(INCPREFIX:\=/)/libxml2 >>$@
++        echo Cflags: -I$(INCPREFIX:\=/)/libxml2 -I$(INCPREFIX:\=/) >>$@
  
  libxml : $(BINDIR)\$(XML_SO) 
  

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0004-CVE-2017-8872.patch
 
 build:
-  number: 2
+  number: 3
   run_exports:
     # remove symbols at minor versions.
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/


### PR DESCRIPTION
This is a follow up of https://github.com/conda-forge/libxml2-feedstock/pull/68 . While that PR fixes the CMake problem, on some projects with the latest package the compilation fails anyhow with error (see https://github.com/robotology/robotology-superbuild/issues/1206):
~~~
2022-07-05T03:48:17.7815682Z C:\Miniconda3\envs\test\Library\include\libxml2\libxml/encoding.h(28,10): fatal error C1083: Cannot open include file: 'iconv.h': No such file or directory [D:\a\robotology-superbuild\robotology-superbuild\build\src\iDynTree\src\model_io\xml\idyntree-modelio-xml.vcxproj] [D:\a\robotology-superbuild\robotology-superbuild\build\iDynTree.vcxproj]
~~~

The problem is that `iconv.h` headers are installed in the root include directory, and that is not covered in the latest .pc . If you check the .pc file generated in Linux, indeed the include line is:
~~~
Cflags: -I${includedir}/libxml2 -I/home/conda/feedstock_root/build_artifacts/libxml2_1656914900982/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla/include 
~~~

So both `${includedir}/libxml2` and `${includedir}` (in this case already expanded) are listed in the include directories. So aligning the Linux and Windows .pc files should again fix the compilation problems that https://github.com/conda-forge/libxml2-feedstock/pull/66 and https://github.com/conda-forge/libxml2-feedstock/pull/67 introduced. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
