### PR TITLE
Enable legacy and ftp for 2.9 compatability

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,6 +15,8 @@ export CPPFLAGS="${CPPFLAGS} -DFALSE=0 -DTRUE=1"
             --with-zlib="${PREFIX}" \
             --with-icu \
             --with-lzma="${PREFIX}" \
+            --with-ftp \
+            --with-legacy \
             --without-python \
             --enable-static=no
 make -j${CPU_COUNT} ${VERBOSE_AT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0004-CVE-2017-8872.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # remove symbols at minor versions.
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/


### PR DESCRIPTION
This fixes https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/329 (verified this locally!)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
