### PR TITLE
drop python from host, cleanup libiconv

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,6 +6,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+libiconv:
+- '1'
 target_platform:
 - win-64
 zlib:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,8 +6,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-libiconv:
-- '1'
 target_platform:
 - win-64
 zlib:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - libiconv  # [not win]
   host:
     - icu  # [not win]
-    - libiconv  # [not win]
+    - libiconv
     - xz  # [not win]
     - zlib
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # remove symbols at minor versions.
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/
@@ -32,11 +32,9 @@ requirements:
     - libiconv  # [not win]
   host:
     - icu  # [not win]
-    - libiconv
+    - libiconv  # [not win]
     - xz  # [not win]
     - zlib
-    - python >=3.10,<3.11  # [not win]
-    - libiconv  # [not win]
 
 test:
   files:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

having python 3.10 requirement in host seems to be causing troubles conda-forge/postgresql-feedstock#160

@conda-forge-admin, please rerender