### PR TITLE
Ensure bash activation scripts use LF line endings

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,9 +7,9 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.12'
+- '2.17'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,4 +28,4 @@ zip_keys:
 - - c_stdlib_version
   - cdt_name
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -32,4 +32,4 @@ zip_keys:
 - - c_stdlib_version
   - cdt_name
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -28,4 +28,4 @@ zip_keys:
 - - c_stdlib_version
   - cdt_name
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -27,4 +27,4 @@ target_platform:
 xz:
 - '5'
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -27,4 +27,4 @@ target_platform:
 xz:
 - '5'
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -13,4 +13,4 @@ libiconv:
 target_platform:
 - win-64
 zlib:
-- '1.2'
+- '1'

--- a/.gitattributes
+++ b/.gitattributes
@@ -25,8 +25,3 @@ bld.bat text eol=crlf
 azure-pipelines.yml linguist-generated=true
 build-locally.py linguist-generated=true
 shippable.yml linguist-generated=true
-
-# explicitly set LF line endings for these files even on windows
-# because we need to support (de)activation from bash
-/recipe/activate.sh text eol=lf
-/recipe/deactivate.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -25,3 +25,8 @@ bld.bat text eol=crlf
 azure-pipelines.yml linguist-generated=true
 build-locally.py linguist-generated=true
 shippable.yml linguist-generated=true
+
+# explicitly set LF line endings for these files even on windows
+# because we need to support (de)activation from bash
+/recipe/activate.sh text eol=lf
+/recipe/deactivate.sh text eol=lf

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -72,6 +72,13 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -85,6 +85,13 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -58,6 +58,11 @@ echo Building recipe
 conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
+call :start_group "Inspecting artifacts"
+:: inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+WHERE inspect_artifacts >nul 2>nul && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+call :end_group
+
 :: Prepare some environment variables for the upload step
 if /i "%CI%" == "github_actions" (
     set "FEEDSTOCK_NAME=%GITHUB_REPOSITORY:*/=%"

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 
 if test -n "${XML_CATALOG_FILES:-}"; then
     xml_catalog_files_libxml2="${XML_CATALOG_FILES}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # remove symbols at minor versions according to
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/
@@ -38,10 +38,18 @@ requirements:
     - zlib
 
 test:
+  requires:
+    - ripgrep
   files:
     - test.xml
   commands:
     - xmllint test.xml
+    # ensure (de)activation scripts for bash-on-win do not contain crlf line endings;
+    # ripgrep will return exit code 1 if no match is found, which is what we want after
+    # filtering to the carriage-return character that shouldn't be there.
+    {% for task in ["activate", "deactivate"] %}
+    - type %CONDA_PREFIX%\etc\conda\{{ task }}.d\libxml2_{{ task }}.sh | rg \r & if %ERRORLEVEL% NEQ 1 (exit 0) else (exit 1)  # [win]
+    {% endfor %}
 
 about:
   home: http://xmlsoft.org/


### PR DESCRIPTION
Same fix as https://github.com/conda-forge/openssl-feedstock/pull/167

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
