### PR TITLE
Use `liblzma` instead of `xz`

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,27 +11,27 @@ jobs:
       linux_64_with_icuno:
         CONFIG: linux_64_with_icuno
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_with_icuyes:
         CONFIG: linux_64_with_icuyes
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_with_icuno:
         CONFIG: linux_aarch64_with_icuno
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_with_icuyes:
         CONFIG: linux_aarch64_with_icuyes
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_with_icuno:
         CONFIG: linux_ppc64le_with_icuno
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
       linux_ppc64le_with_icuyes:
         CONFIG: linux_ppc64le_with_icuyes
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -24,6 +24,7 @@ jobs:
       displayName: Run Windows build
       env:
         MINIFORGE_HOME: $(MINIFORGE_HOME)
+        CONDA_BLD_PATH: $(CONDA_BLD_PATH)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.ci_support/linux_64_with_icuno.yaml
+++ b/.ci_support/linux_64_with_icuno.yaml
@@ -15,16 +15,18 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 icu:
 - '75'
 libiconv:
 - '1'
+liblzma_devel:
+- '5'
+libxml2:
+- '2'
 target_platform:
 - linux-64
 with_icu:
 - 'no'
-xz:
-- '5'
 zlib:
 - '1'

--- a/.ci_support/linux_64_with_icuyes.yaml
+++ b/.ci_support/linux_64_with_icuyes.yaml
@@ -15,16 +15,18 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 icu:
 - '75'
 libiconv:
 - '1'
+liblzma_devel:
+- '5'
+libxml2:
+- '2'
 target_platform:
 - linux-64
 with_icu:
 - 'yes'
-xz:
-- '5'
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_with_icuno.yaml
+++ b/.ci_support/linux_aarch64_with_icuno.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 VERBOSE_AT:
 - V=1
 c_compiler:
@@ -10,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -19,16 +15,18 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 icu:
 - '75'
 libiconv:
 - '1'
+liblzma_devel:
+- '5'
+libxml2:
+- '2'
 target_platform:
 - linux-aarch64
 with_icu:
 - 'no'
-xz:
-- '5'
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_with_icuyes.yaml
+++ b/.ci_support/linux_aarch64_with_icuyes.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 VERBOSE_AT:
 - V=1
 c_compiler:
@@ -10,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -19,16 +15,18 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 icu:
 - '75'
 libiconv:
 - '1'
+liblzma_devel:
+- '5'
+libxml2:
+- '2'
 target_platform:
 - linux-aarch64
 with_icu:
 - 'yes'
-xz:
-- '5'
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_with_icuno.yaml
+++ b/.ci_support/linux_ppc64le_with_icuno.yaml
@@ -15,16 +15,18 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
 icu:
 - '75'
 libiconv:
 - '1'
+liblzma_devel:
+- '5'
+libxml2:
+- '2'
 target_platform:
 - linux-ppc64le
 with_icu:
 - 'no'
-xz:
-- '5'
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_with_icuyes.yaml
+++ b/.ci_support/linux_ppc64le_with_icuyes.yaml
@@ -15,16 +15,18 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
 icu:
 - '75'
 libiconv:
 - '1'
+liblzma_devel:
+- '5'
+libxml2:
+- '2'
 target_platform:
 - linux-ppc64le
 with_icu:
 - 'yes'
-xz:
-- '5'
 zlib:
 - '1'

--- a/.ci_support/osx_64_with_icuno.yaml
+++ b/.ci_support/osx_64_with_icuno.yaml
@@ -20,13 +20,15 @@ icu:
 - '75'
 libiconv:
 - '1'
+liblzma_devel:
+- '5'
+libxml2:
+- '2'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:
 - osx-64
 with_icu:
 - 'no'
-xz:
-- '5'
 zlib:
 - '1'

--- a/.ci_support/osx_64_with_icuyes.yaml
+++ b/.ci_support/osx_64_with_icuyes.yaml
@@ -20,13 +20,15 @@ icu:
 - '75'
 libiconv:
 - '1'
+liblzma_devel:
+- '5'
+libxml2:
+- '2'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:
 - osx-64
 with_icu:
 - 'yes'
-xz:
-- '5'
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_with_icuno.yaml
+++ b/.ci_support/osx_arm64_with_icuno.yaml
@@ -20,13 +20,15 @@ icu:
 - '75'
 libiconv:
 - '1'
+liblzma_devel:
+- '5'
+libxml2:
+- '2'
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:
 - osx-arm64
 with_icu:
 - 'no'
-xz:
-- '5'
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_with_icuyes.yaml
+++ b/.ci_support/osx_arm64_with_icuyes.yaml
@@ -20,13 +20,15 @@ icu:
 - '75'
 libiconv:
 - '1'
+liblzma_devel:
+- '5'
+libxml2:
+- '2'
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:
 - osx-arm64
 with_icu:
 - 'yes'
-xz:
-- '5'
 zlib:
 - '1'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -10,6 +10,8 @@ channel_targets:
 - conda-forge main
 libiconv:
 - '1'
+libxml2:
+- '2'
 target_platform:
 - win-64
 with_icu:

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -36,6 +36,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
 del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+call :end_group
 
 call :start_group "Configuring conda"
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # remove symbols at minor versions according to
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/
@@ -34,7 +34,7 @@ requirements:
   host:
     - libiconv
     - icu  # [with_icu == "yes"]
-    - xz  # [not win]
+    - liblzma-devel  # [not win]
     - zlib
   run_constrained:
     - icu <0.0a0  # [with_icu != "yes" and not win]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Switching from building using `xz` to `liblzma` due to splitted `xz` outputs which are differently lincensed:

- `0BSD` licensed `liblzma` and 
- two `xz-tools` packages being `LGPL-2.1-or-later` and `GPL-2.0-or-later` labeled.   

<!--
Please add any other relevant info below:
-->
